### PR TITLE
Merge branch to `main` for: modifying installer to include third-party plugins

### DIFF
--- a/Src/BlueDotBrigade.Weevil.Plugins/BlueDotBrigade.Weevil.Plugins.csproj
+++ b/Src/BlueDotBrigade.Weevil.Plugins/BlueDotBrigade.Weevil.Plugins.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<Platforms>x64</Platforms>
-		<PackageId>BlueDotBrigade.Weevil.Plugins</PackageId>
 		<RootNamespace>BlueDotBrigade.Weevil.Plugins</RootNamespace>
 		<Version>2.10.0</Version>
 		<Authors>BlueDotBrigade;</Authors>
@@ -10,22 +9,23 @@
 		<Owners>Blue Dot Brigade</Owners>
 		<Description>This project dynamically detects the plugin files from %WEEVIL_PLUGINS_PATH%, so that thay can be added to the installation package.</Description>
 		<IsPackable>False</IsPackable>
-		<PackageReleaseNotes></PackageReleaseNotes>
-		<PackageTags>BlueDotBrigade; Weevil; Log Viewer;</PackageTags>
-		<RepositoryType>git</RepositoryType>
-		<PackageProjectUrl>https://github.com/BlueDotBrigade/weevil</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/BlueDotBrigade/weevil.git</RepositoryUrl>
 		<AssemblyVersion>2.10.0.0</AssemblyVersion>
 		<FileVersion>2.10.0.0</FileVersion>
+		<ProduceReferenceAssembly>False</ProduceReferenceAssembly>
 	</PropertyGroup>
-	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-	  <Exec Command="IF &quot;%25WEEVIL_PLUGINS_PATH%25&quot;==&quot;&quot;  (&#xD;&#xA;   ECHO $(ProjectFileName): warning BDB: `WEEVIL_PLUGINS_PATH` environment variable is missing.&#xD;&#xA;)" />
-	</Target>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
 		<WarningLevel>4</WarningLevel>
+		<DebugType>none</DebugType>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<DebugType>none</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
-		<Content Include="$(WEEVIL_PLUGINS_PATH)\**\*.dll" LinkBase="Plugins" CopyToOutputDirectory="PreserveNewest" />
-		<Content Include="$(WEEVIL_PLUGINS_PATH)\**\*.pdb" LinkBase="Plugins" CopyToOutputDirectory="PreserveNewest" />
+		<Content Include="*.dll" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
+		<Content Include="*.dll.config" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
+		<Content Include="*.pdb" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
 	</ItemGroup>
+	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+	  <Exec Command="IF &quot;%25WEEVIL_PLUGINS_PATH%25&quot;==&quot;&quot;  (&#xD;&#xA;   ECHO $(ProjectFileName): warning BDB: `WEEVIL_PLUGINS_PATH` environment variable is missing&#xD;&#xA;)" />
+	</Target>
 </Project>

--- a/Src/BlueDotBrigade.Weevil.Plugins/ReadMe.md
+++ b/Src/BlueDotBrigade.Weevil.Plugins/ReadMe.md
@@ -12,14 +12,14 @@ This project is used as a staging area for Weevil plugins.  With this in mind, i
 Environment setup:
 
 1. Download the Weevil source code from GitHub.
-2. Create a Windows `WEEVIL_PLUGINS_PATH` environment variable which points to the `Staging` subdirectory.
+2. Create a Windows `WEEVIL_PLUGINS_PATH` environment variable that points to the`BlueDotBrigade.Weevil.Plugins` directory.
 
 Modifying third-party plugin:
 
 1. In a separate solution, create a new C# project for a vendor specific Weevil plugin.
 2. Modify the post build step to copy the plugin's assemblies to `WEEVIL_PLUGINS_PATH`.
 3. Add a new feature to the plugin.
-4. Compile the project so that the plugin will be pushed to the staging area.
+4. Compile all third-party plugins so that the appropriate output is copied to `WEEVIL_PLUGINS_PATH`. 
 
 Compiling Weevil:
 

--- a/Src/BlueDotBrigade.Weevil.Setup/BlueDotBrigade.Weevil.Setup.vdproj
+++ b/Src/BlueDotBrigade.Weevil.Setup/BlueDotBrigade.Weevil.Setup.vdproj
@@ -15,12 +15,6 @@
     {
         "Entry"
         {
-        "MsmKey" = "8:_067810465A434DDB93196BD8B05E60D5"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_0A3BC7A196BB4E1CBFE9C3F6D5A3897C"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -430,7 +424,7 @@
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:Weevil"
         "ProductCode" = "8:{E8A89882-0897-4035-A4D2-58E48BADADEB}"
-        "PackageCode" = "8:{B12FB0C7-0B68-4CD2-A53E-64C7F5E69800}"
+        "PackageCode" = "8:{E31175DC-B1B7-419F-8B35-021E6CC33918}"
         "UpgradeCode" = "8:{67E64001-DCF2-480F-9E5D-9B8DC5AEB41E}"
         "AspNetVersion" = "8:2.0.50727.0"
         "RestartWWWService" = "11:FALSE"
@@ -1085,35 +1079,7 @@
         }
         "ProjectOutput"
         {
-            "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_067810465A434DDB93196BD8B05E60D5"
-            {
-            "SourcePath" = "8:..\\BlueDotBrigade.Weevil.Plugins\\obj\\x64\\Release\\net6.0\\BlueDotBrigade.Weevil.Plugins.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_B8D829AE304D4719B554D19C3C08B0E1"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            "ProjectOutputGroupRegister" = "3:1"
-            "OutputConfiguration" = "8:Release|x64"
-            "OutputGroupCanonicalName" = "8:Built"
-            "OutputProjectGuid" = "8:{69A3C95D-7B0F-46C4-B370-AE22CB3AA2DC}"
-            "ShowKeyOutput" = "11:TRUE"
-                "ExcludeFilters"
-                {
-                }
-            }
-            "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_39A6BD26902A4BE6B5FF8248E429D0B0"
+            "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_1590BBD7B894424D901C17FDD1342BB9"
             {
             "SourcePath" = "8:"
             "TargetName" = "8:"
@@ -1134,11 +1100,12 @@
             "IsolateTo" = "8:"
             "ProjectOutputGroupRegister" = "3:1"
             "OutputConfiguration" = "8:Release|x64"
-            "OutputGroupCanonicalName" = "8:Symbols"
-            "OutputProjectGuid" = "8:{69A3C95D-7B0F-46C4-B370-AE22CB3AA2DC}"
+            "OutputGroupCanonicalName" = "8:PublishItems"
+            "OutputProjectGuid" = "8:{8DD59BAD-4E11-45A9-861D-14A4046C1D96}"
             "ShowKeyOutput" = "11:TRUE"
                 "ExcludeFilters"
                 {
+                "ExcludeFilter" = "8:BlueDotBrigade.Weevil.Plugins*"
                 }
             }
             "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_4113A22BFE00441D86F13F5030239638"
@@ -1164,34 +1131,6 @@
             "OutputConfiguration" = "8:Release|x64"
             "OutputGroupCanonicalName" = "8:PublishItemsOutputGroup"
             "OutputProjectGuid" = "8:{655E4324-C7C5-4314-87CE-748CDFD20004}"
-            "ShowKeyOutput" = "11:TRUE"
-                "ExcludeFilters"
-                {
-                }
-            }
-            "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_6EE32F408EDB4C9787EB9E1BD2CE87FF"
-            {
-            "SourcePath" = "8:"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_B8D829AE304D4719B554D19C3C08B0E1"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            "ProjectOutputGroupRegister" = "3:1"
-            "OutputConfiguration" = "8:"
-            "OutputGroupCanonicalName" = "8:PublishItems"
-            "OutputProjectGuid" = "8:{69A3C95D-7B0F-46C4-B370-AE22CB3AA2DC}"
             "ShowKeyOutput" = "11:TRUE"
                 "ExcludeFilters"
                 {

--- a/Weevil-v2.sln
+++ b/Weevil-v2.sln
@@ -37,13 +37,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlueDotBrigade.Weevil.Gui",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlueDotBrigade.Weevil.Core", "Src\BlueDotBrigade.Weevil.Core\BlueDotBrigade.Weevil.Core.csproj", "{F9E8412F-BD0F-4DB0-AAA9-EC7B55DE19ED}"
 EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "BlueDotBrigade.Weevil.Plugins", "Src\BlueDotBrigade.Weevil.Plugins\BlueDotBrigade.Weevil.Plugins.shproj", "{BCC424C0-8D0A-428D-B967-52F0D98856B9}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlueDotBrigade.Weevil.Core-IntegrationTests", "Tst\BlueDotBrigade.Weevil.Core-IntegrationTests\BlueDotBrigade.Weevil.Core-IntegrationTests.csproj", "{6A41C95F-EADC-4B0F-82ED-8F00D36BBFAF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlueDotBrigade.Weevil.Core-UnitTests", "Tst\BlueDotBrigade.Weevil.Core-UnitTests\BlueDotBrigade.Weevil.Core-UnitTests.csproj", "{35DCC175-B682-47E0-A2B8-C0F123A1E2AA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlueDotBrigade.Weevil.Plugins", "Src\BlueDotBrigade.Weevil.Plugins\BlueDotBrigade.Weevil.Plugins.csproj", "{8DD59BAD-4E11-45A9-861D-14A4046C1D96}"
+EndProject
+Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "BlueDotBrigade.Weevil.Setup", "Src\BlueDotBrigade.Weevil.Setup\BlueDotBrigade.Weevil.Setup.vdproj", "{FB1F80DC-BECE-458E-8BB3-FB7308AE2AE1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -94,6 +94,10 @@ Global
 		{8DD59BAD-4E11-45A9-861D-14A4046C1D96}.Debug|x64.Build.0 = Debug|x64
 		{8DD59BAD-4E11-45A9-861D-14A4046C1D96}.Release|x64.ActiveCfg = Release|x64
 		{8DD59BAD-4E11-45A9-861D-14A4046C1D96}.Release|x64.Build.0 = Release|x64
+		{FB1F80DC-BECE-458E-8BB3-FB7308AE2AE1}.Debug|x64.ActiveCfg = Debug
+		{FB1F80DC-BECE-458E-8BB3-FB7308AE2AE1}.Debug|x64.Build.0 = Debug
+		{FB1F80DC-BECE-458E-8BB3-FB7308AE2AE1}.Release|x64.ActiveCfg = Release
+		{FB1F80DC-BECE-458E-8BB3-FB7308AE2AE1}.Release|x64.Build.0 = Release
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,8 +114,5 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {94508D1B-CE45-43A7-8D41-50927BFA3696}
-	EndGlobalSection
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Src\BlueDotBrigade.Weevil.Plugins\BlueDotBrigade.Weevil.Plugins.projitems*{bcc424c0-8d0a-428d-b967-52f0d98856b9}*SharedItemsImports = 13
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Fix : At compile time, `WEEVIL_PLUGINS_PATH` plugin files are automatically copied to the `BlueDotBrigade.Weevil.Plugins` output `Bin` directory.  When the `Setup` project creates the installer... the plugin files will automatically be detected.