### PR TITLE
Implement quick bookmark navigation

### DIFF
--- a/Src/BlueDotBrigade.Weevil.Gui/Converters/BookmarkStringConverter.cs
+++ b/Src/BlueDotBrigade.Weevil.Gui/Converters/BookmarkStringConverter.cs
@@ -30,19 +30,30 @@
 		///   values[1]: The parent FilterViewModel (the DataContext of the UserControl/Window)
 		///   values[2]: True indicates that a tooltip is being created.
 		/// </summary>
-		public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
-		{
-			if (values?.Length < 2)
-				return string.Empty;
+                public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+                {
+                        if (values?.Length < 2)
+                                return string.Empty;
 
-			var record = values[0] as IRecord;
-			var viewModel = values[1] as FilterViewModel;
+                        var record = values[0] as IRecord;
+                        var viewModel = values[1] as FilterViewModel;
 
-			if (record == null || viewModel == null)
-				return string.Empty;
+                        if (record == null || viewModel == null)
+                                return string.Empty;
 
-			return "Bookmark";
-		}
+                        bool isToolTip = false;
+                        if (values.Length >= 3)
+                        {
+                                bool.TryParse(values[2]?.ToString(), out isToolTip);
+                        }
+
+                        if (viewModel.TryGetBookmarkName(record, out var bookmarkName))
+                        {
+                                return isToolTip ? $"Bookmark: {bookmarkName}" : $"🔖 {bookmarkName} ";
+                        }
+
+                        return string.Empty;
+                }
 
 		public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
 		{

--- a/Src/BlueDotBrigade.Weevil.Gui/Filter/FilterView.xaml
+++ b/Src/BlueDotBrigade.Weevil.Gui/Filter/FilterView.xaml
@@ -47,6 +47,12 @@
         <KeyBinding Key="B" Modifiers="Ctrl" Command="{Binding AddRegionCommand}" />
 
         <KeyBinding Key="N" Modifiers="Ctrl" Command="{Binding AddBookmarkCommand}" />
+        <KeyBinding Key="D1" Modifiers="Ctrl+Shift" Command="{Binding SetBookmark1Command}" />
+        <KeyBinding Key="D2" Modifiers="Ctrl+Shift" Command="{Binding SetBookmark2Command}" />
+        <KeyBinding Key="D3" Modifiers="Ctrl+Shift" Command="{Binding SetBookmark3Command}" />
+        <KeyBinding Key="D1" Modifiers="Ctrl" Command="{Binding GoToBookmark1Command}" />
+        <KeyBinding Key="D2" Modifiers="Ctrl" Command="{Binding GoToBookmark2Command}" />
+        <KeyBinding Key="D3" Modifiers="Ctrl" Command="{Binding GoToBookmark3Command}" />
 
         <KeyBinding Key="F" Modifiers="Ctrl" Command="{Binding FindTextCommand}" />
         <KeyBinding Key="F3" Command="{Binding FindNextCommand}" />
@@ -318,7 +324,12 @@
                         <Separator/>
                         <MenuItem Header="Go To" Command="{Binding GoToCommand}" InputGestureText="Ctrl+G" />
                         <Separator/>
-                        <MenuItem Header="Add Bookmark" Command="{Binding AddBookmarkCommand}" InputGestureText="Ctrl+1" />
+                        <MenuItem Header="Set Bookmark 1" Command="{Binding SetBookmark1Command}" InputGestureText="Ctrl+Shift+1" />
+                        <MenuItem Header="Set Bookmark 2" Command="{Binding SetBookmark2Command}" InputGestureText="Ctrl+Shift+2" />
+                        <MenuItem Header="Set Bookmark 3" Command="{Binding SetBookmark3Command}" InputGestureText="Ctrl+Shift+3" />
+                        <MenuItem Header="Go To Bookmark 1" Command="{Binding GoToBookmark1Command}" InputGestureText="Ctrl+1" />
+                        <MenuItem Header="Go To Bookmark 2" Command="{Binding GoToBookmark2Command}" InputGestureText="Ctrl+2" />
+                        <MenuItem Header="Go To Bookmark 3" Command="{Binding GoToBookmark3Command}" InputGestureText="Ctrl+3" />
                         <MenuItem Header="Remove Bookmark" Command="{Binding RemoveBookmarkCommand}"/>
                         <MenuItem Header="Remove All Bookmarks" Command="{Binding RemoveAllBookmarksCommand}" />
                         <Separator/>
@@ -489,9 +500,9 @@
                                             </TextBlock.Text>
                                         </TextBlock>
                                     </Border>
-                                    <!--<Border x:Name="BookmarkTag" 
-                                            BorderBrush="#949494" BorderThickness="1" CornerRadius="4" 
-                                            Margin="0,0,0,-2" 
+                                    <Border x:Name="BookmarkTag"
+                                            BorderBrush="#949494" BorderThickness="1" CornerRadius="4"
+                                            Margin="0,0,0,-2"
                                             Background="#3c3c3c">
                                          <Border.Style>
                                             <Style TargetType="Border">
@@ -513,14 +524,12 @@
                                             </TextBlock.ToolTip>
                                             <TextBlock.Text>
                                                 <MultiBinding Converter="{StaticResource BookmarkStringConverter}">
-                                                    --><!-- 1) The current item (record) --><!--
                                                     <Binding Path="." />
-                                                    --><!-- 2) The parent ViewModel (the UserControl.DataContext) --><!--
                                                     <Binding Path="DataContext" RelativeSource="{RelativeSource AncestorType=UserControl}" />
                                                 </MultiBinding>
                                             </TextBlock.Text>
                                         </TextBlock>
-                                    </Border>-->
+                                    </Border>
                                     <Border 
                                         x:Name="TruncatedTag"
                                         BorderBrush="#949494" BorderThickness="1" CornerRadius="4" 

--- a/Src/BlueDotBrigade.Weevil.Gui/Filter/FilterView.xaml.cs
+++ b/Src/BlueDotBrigade.Weevil.Gui/Filter/FilterView.xaml.cs
@@ -26,17 +26,19 @@
 				{
 					var viewModel = args.OldValue as FilterViewModel;
 
-					viewModel.FileOpened -= OnFileOpened;
-					viewModel.ResultsChanged -= OnResultsChanged;
-					viewModel.RegionsChanged -= OnRegionsChanged;
+                                        viewModel.FileOpened -= OnFileOpened;
+                                        viewModel.ResultsChanged -= OnResultsChanged;
+                                        viewModel.RegionsChanged -= OnRegionsChanged;
+                                        viewModel.BookmarksChanged -= OnBookmarksChanged;
 				}
 				if (args.NewValue != null)
 				{
 					var viewModel = args.NewValue as FilterViewModel;
 
-					viewModel.FileOpened += OnFileOpened;
-					viewModel.ResultsChanged += OnResultsChanged;
-					viewModel.RegionsChanged += OnRegionsChanged;
+                                        viewModel.FileOpened += OnFileOpened;
+                                        viewModel.ResultsChanged += OnResultsChanged;
+                                        viewModel.RegionsChanged += OnRegionsChanged;
+                                        viewModel.BookmarksChanged += OnBookmarksChanged;
 				}
 			};
 
@@ -72,11 +74,17 @@
 			_isLogFileOpening = true;
 		}
 
-		private void OnRegionsChanged(object sender, EventArgs e)
-		{
-			// Force bindings (and converters) for only the visible items to be refreshed.
-			this.ListView.Items.Refresh();
-		}
+                private void OnRegionsChanged(object sender, EventArgs e)
+                {
+                        // Force bindings (and converters) for only the visible items to be refreshed.
+                        this.ListView.Items.Refresh();
+                }
+
+                private void OnBookmarksChanged(object sender, EventArgs e)
+                {
+                        // Force bindings (and converters) for only the visible items to be refreshed.
+                        this.ListView.Items.Refresh();
+                }
 
 		private void OnResultsChanged(object sender, EventArgs e)
 		{

--- a/Src/BlueDotBrigade.Weevil.Gui/Filter/FilterViewModel.Commands.cs
+++ b/Src/BlueDotBrigade.Weevil.Gui/Filter/FilterViewModel.Commands.cs
@@ -316,7 +316,25 @@ namespace BlueDotBrigade.Weevil.Gui.Filter
 		public ICommand RemoveBookmarkCommand => new UiBoundCommand(RemoveBookmark, () => this.IsMenuEnabled);
 
 		[SafeForDependencyAnalysis]
-		public ICommand RemoveAllBookmarksCommand => new UiBoundCommand(RemoveAllBookmarks, () => this.IsMenuEnabled);
-		#endregion
-	}
+                public ICommand RemoveAllBookmarksCommand => new UiBoundCommand(RemoveAllBookmarks, () => this.IsMenuEnabled);
+
+                [SafeForDependencyAnalysis]
+                public ICommand SetBookmark1Command => new UiBoundCommand(() => SetBookmark(1), () => this.IsMenuEnabled);
+
+                [SafeForDependencyAnalysis]
+                public ICommand SetBookmark2Command => new UiBoundCommand(() => SetBookmark(2), () => this.IsMenuEnabled);
+
+                [SafeForDependencyAnalysis]
+                public ICommand SetBookmark3Command => new UiBoundCommand(() => SetBookmark(3), () => this.IsMenuEnabled);
+
+                [SafeForDependencyAnalysis]
+                public ICommand GoToBookmark1Command => new UiBoundCommand(() => GoToBookmark(1), () => this.IsMenuEnabled);
+
+                [SafeForDependencyAnalysis]
+                public ICommand GoToBookmark2Command => new UiBoundCommand(() => GoToBookmark(2), () => this.IsMenuEnabled);
+
+                [SafeForDependencyAnalysis]
+                public ICommand GoToBookmark3Command => new UiBoundCommand(() => GoToBookmark(3), () => this.IsMenuEnabled);
+                #endregion
+        }
 }

--- a/Tst/BlueDotBrigade.Weevil.Core-UnitTests/BookmarkManagerTests.cs
+++ b/Tst/BlueDotBrigade.Weevil.Core-UnitTests/BookmarkManagerTests.cs
@@ -1,0 +1,75 @@
+using System;
+using BlueDotBrigade.Weevil.Core;
+
+namespace BlueDotBrigade.Weevil.Core.UnitTests
+{
+        [TestClass]
+        public class BookmarkManagerTests
+        {
+                private BookmarkManager _bookmarkManager;
+
+                [TestInitialize]
+                public void Setup()
+                {
+                        _bookmarkManager = new BookmarkManager();
+                }
+
+                [TestMethod]
+                public void CreateFromSelection_SingleBookmark_BookmarkCreated()
+                {
+                        // Arrange
+                        int lineNumber = 42;
+
+                        // Act
+                        _bookmarkManager.CreateFromSelection("Test", lineNumber);
+
+                        // Assert
+                        _bookmarkManager.Bookmarks.Length.Should().Be(1);
+                        _bookmarkManager.Bookmarks[0].Name.Should().Be("Test");
+                        _bookmarkManager.Bookmarks[0].Record.LineNumber.Should().Be(lineNumber);
+                }
+
+                [TestMethod]
+                public void CreateFromSelection_DuplicateLine_ThrowsInvalidOperationException()
+                {
+                        // Arrange
+                        int lineNumber = 42;
+                        _bookmarkManager.CreateFromSelection("A", lineNumber);
+
+                        // Act
+                        Action act = () => _bookmarkManager.CreateFromSelection("B", lineNumber);
+
+                        // Assert
+                        act.Should().Throw<InvalidOperationException>();
+                }
+
+                [TestMethod]
+                public void Clear_LineNumber_RemovesBookmark()
+                {
+                        // Arrange
+                        int lineNumber = 42;
+                        _bookmarkManager.CreateFromSelection("A", lineNumber);
+
+                        // Act
+                        var wasCleared = _bookmarkManager.Clear(lineNumber);
+
+                        // Assert
+                        wasCleared.Should().BeTrue();
+                        _bookmarkManager.Bookmarks.Length.Should().Be(0);
+                }
+
+                [TestMethod]
+                public void Clear_All_RemovesBookmarks()
+                {
+                        // Arrange
+                        _bookmarkManager.CreateFromSelection("A", 1);
+                        _bookmarkManager.CreateFromSelection("B", 2);
+
+                        // Act
+                        _bookmarkManager.Clear();
+
+                        // Assert
+                        _bookmarkManager.Bookmarks.Length.Should().Be(0);
+                }
+        }
+}


### PR DESCRIPTION
## Summary

For completing #197
- add commands for setting and jumping to bookmark slots 1-3
- wire new key bindings and menu items in `FilterView`
- implement bookmark slot helpers in the view model

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c9fe2bb4c832ebe563b6604c2da8b