### PR TITLE
Prevent re-entrant selection loop after Ctrl+Shift comment navigation

### DIFF
--- a/Src/BlueDotBrigade.Weevil.Gui/Filter/FilterView.xaml.cs
+++ b/Src/BlueDotBrigade.Weevil.Gui/Filter/FilterView.xaml.cs
@@ -126,6 +126,12 @@
 		{
 			if (e.PropertyName == nameof(FilterViewModel.ActiveRecordIndex))
 			{
+				if (ShouldSkipActiveRecordIndexHandlingDuringProgrammaticUpdate(_isProgrammaticSelectionUpdate))
+				{
+					// Prevent re-entrant processing when selection is being normalized during Ctrl+Shift navigation.
+					return;
+				}
+
 				var index = this.ViewModel.ActiveRecordIndex;
 				if (index >= 0 && index < this.ListView.Items.Count)
 				{
@@ -162,6 +168,11 @@
 		}
 
 		internal static bool ShouldSuppressSelectionChangedDuringProgrammaticUpdate(bool isProgrammaticSelectionUpdate)
+		{
+			return isProgrammaticSelectionUpdate;
+		}
+
+		internal static bool ShouldSkipActiveRecordIndexHandlingDuringProgrammaticUpdate(bool isProgrammaticSelectionUpdate)
 		{
 			return isProgrammaticSelectionUpdate;
 		}

--- a/Tst/BlueDotBrigade.Weevil.Gui-FeatureTests/Filter/FilterViewTests.cs
+++ b/Tst/BlueDotBrigade.Weevil.Gui-FeatureTests/Filter/FilterViewTests.cs
@@ -28,5 +28,21 @@ namespace BlueDotBrigade.Weevil.Gui.Filter
 
 			shouldNormalize.Should().BeFalse();
 		}
+
+		[TestMethod]
+		public void GivenProgrammaticSelectionUpdate_WhenCheckingActiveRecordIndexHandling_ThenReturnsTrue()
+		{
+			var shouldSkip = FilterView.ShouldSkipActiveRecordIndexHandlingDuringProgrammaticUpdate(true);
+
+			shouldSkip.Should().BeTrue();
+		}
+
+		[TestMethod]
+		public void GivenNoProgrammaticSelectionUpdate_WhenCheckingActiveRecordIndexHandling_ThenReturnsFalse()
+		{
+			var shouldSkip = FilterView.ShouldSkipActiveRecordIndexHandlingDuringProgrammaticUpdate(false);
+
+			shouldSkip.Should().BeFalse();
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Fix a UI-freeze regression where repeated programmatic selection normalization during `Ctrl+Shift+Plus` comment navigation re-enters `ActiveRecordIndex` handling and causes selection churn/unresponsiveness.

### Description
- Added an early-exit guard in `FilterView.OnViewModelPropertyChanged` to skip `ActiveRecordIndex` handling while a programmatic selection update is in progress. 
- Introduced `ShouldSkipActiveRecordIndexHandlingDuringProgrammaticUpdate(...)` to centralize and document the re-entrancy guard. 
- Added feature tests in `Tst/BlueDotBrigade.Weevil.Gui-FeatureTests/Filter/FilterViewTests.cs` to assert the new guard behavior. 
- Modified `Src/BlueDotBrigade.Weevil.Gui/Filter/FilterView.xaml.cs` and test file to implement and verify the change. 

### Testing
- Added tests: `GivenProgrammaticSelectionUpdate_WhenCheckingActiveRecordIndexHandling_ThenReturnsTrue` and `GivenNoProgrammaticSelectionUpdate_WhenCheckingActiveRecordIndexHandling_ThenReturnsFalse`, but they were not executed in this environment. 
- Attempted to run `dotnet test Weevil-v2.sln`, but the run failed due to missing `dotnet` in the container (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f001218800832b93097b8853d70828)